### PR TITLE
Fix link formatting for Discord in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Questions and issues
 
-If you have questions about implementation details, help or support, or want to report an issue, then please use our dedicated community forum at (DISCORD)[https://discord.com/channels/809809541385682964/809827655770832916].
+If you have questions about implementation details, help or support, or want to report an issue, then please use our dedicated community forum at [Discord](https://discord.com/channels/809809541385682964/809827655770832916).
 
 ## Suggesting new features
 


### PR DESCRIPTION
This PR corrects the markdown link format for the Discord community forum.
